### PR TITLE
feat: Add claiming entity process

### DIFF
--- a/contract/src/entity.rs
+++ b/contract/src/entity.rs
@@ -221,6 +221,13 @@ impl Contract {
         .emit();
     }
 
+    /// Reject a claim request.
+    pub fn reject_claim_entity(&mut self, entity_id: AccountId, contributor_id: AccountId) {
+        self.assert_manager_or_higher(&entity_id, &env::predecessor_account_id());
+        self.requests
+            .remove(&(entity_id.clone(), contributor_id.clone()));
+    }
+
     /// Admin or moderator updates the entity details.
     pub fn set_entity(&mut self, account_id: AccountId, entity: Entity) {
         self.assert_manager_or_higher(&account_id, &env::predecessor_account_id());

--- a/contract/src/events.rs
+++ b/contract/src/events.rs
@@ -59,6 +59,13 @@ pub enum Events {
         #[serde(with = "u64_dec_format")]
         start_date: Timestamp,
     },
+    ClaimEntity {
+        entity_id: AccountId,
+        contributor_id: AccountId,
+        approver_id: AccountId,
+        #[serde(with = "u64_dec_format")]
+        start_date: Timestamp,
+    },
 }
 
 impl Events {


### PR DESCRIPTION
## Claiming entity process

This PR outlines, and proposes a implementation for, how a entity claiming process could happen.

### Setting

The scenario is the following:

We have a entity that was ingested into the system by a moderator without specifying a founder (usually due to lack of information about said founder e.g. missing founder's account ID).

The founder sees the entity listed on the app and want's to take ownership over that account so that they can edit details and manage other process of the entity within the app.

We don't want to allow anyone to just claim any entity automatically so we need to approve this before it goes through.

### Process proposal

#### Step 1

A contributor can request a claim of an entity by calling the `request_claim_entity` function which essentially creates a contribution request with predefined values.

#### Step 2

The moderator can then approve (or reject the claim by calling the `reject_claim_entity`) this claim by calling the `approve_claim_entity` function which will convert the request into a contribution and set the contributor as the founder of the entity.

**Note:** The `approve_claim_entity` function accepts a `remove_current` parameter that allow the user to choose whether the current admin (admin that is approving this claim) will remove their permissions/founder status from the entity. This can be useful if a entity has multiple founders so they can claim the entity and approve those claims without removing their own permissions and/or status.